### PR TITLE
Add Game Center identity verification

### DIFF
--- a/ios/PluginTests/GameCenterPluginTests.swift
+++ b/ios/PluginTests/GameCenterPluginTests.swift
@@ -6,6 +6,16 @@ import GameKit
 class MockLocalPlayer: LocalPlayerProtocol {
     var isAuthenticated: Bool = false
     var authenticateHandler: ((UIViewController?, Error?) -> Void)?
+    var teamPlayerID: String = "testPlayer"
+    var fetchHandler: (() async throws -> (URL, Data, Data, UInt64))?
+
+    @available(iOS 14.0, *)
+    func fetchIdentityVerificationItems() async throws -> (URL, Data, Data, UInt64) {
+        if let handler = fetchHandler {
+            return try await handler()
+        }
+        return (URL(string: "https://static.gc.apple.com")!, Data(), Data(), 0)
+    }
 }
 
 class GameCenterPluginTests: XCTestCase {
@@ -48,6 +58,64 @@ class GameCenterPluginTests: XCTestCase {
         }
 
         plugin.authenticateSilent(call)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testGetVerificationDataSuccess() {
+        let plugin = GameCenterPlugin()
+        let player = MockLocalPlayer()
+        plugin.localPlayer = player
+        player.isAuthenticated = true
+        player.teamPlayerID = "player123"
+        player.fetchHandler = {
+            return (URL(string: "https://static.gc.apple.com")!, Data([1,2]), Data([3,4]), 123)
+        }
+
+        let expectation = self.expectation(description: "resolved")
+        let call = CAPPluginCall(callbackId: "2", methodName: "getVerificationData", options: [:], success: { result, _ in
+            if let dict = result?.data as? [String: Any], dict["playerId"] as? String == "player123" {
+                expectation.fulfill()
+            }
+        }, error: { _ in })
+
+        Task { await plugin.getVerificationData(call) }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testGetVerificationDataNotAuthenticated() {
+        let plugin = GameCenterPlugin()
+        let player = MockLocalPlayer()
+        plugin.localPlayer = player
+        player.isAuthenticated = false
+
+        let expectation = self.expectation(description: "rejected")
+        let call = CAPPluginCall(callbackId: "3", methodName: "getVerificationData", options: [:], success: { _, _ in }, error: { err in
+            if err.code == PluginError.notAuthenticated.rawValue {
+                expectation.fulfill()
+            }
+        })
+
+        Task { await plugin.getVerificationData(call) }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testGetVerificationDataInvalidDomain() {
+        let plugin = GameCenterPlugin()
+        let player = MockLocalPlayer()
+        plugin.localPlayer = player
+        player.isAuthenticated = true
+        player.fetchHandler = {
+            return (URL(string: "https://evil.com")!, Data(), Data(), 100)
+        }
+
+        let expectation = self.expectation(description: "rejected")
+        let call = CAPPluginCall(callbackId: "4", methodName: "getVerificationData", options: [:], success: { _, _ in }, error: { err in
+            if err.code == PluginError.internalError.rawValue {
+                expectation.fulfill()
+            }
+        })
+
+        Task { await plugin.getVerificationData(call) }
         waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
## Summary
- implement `getVerificationData` in Swift plugin
- extend `LocalPlayerProtocol` and add async helper
- add XCTest covering success and error cases

## Testing
- `npm run build`
- `npm run sync:ios`
- `npm run test:native` (skipped on non-macOS)

------
https://chatgpt.com/codex/tasks/task_e_688692d2fd2083209308b7096cf5ce97